### PR TITLE
modsec2lua tool

### DIFF
--- a/tools/modsec2lua-resty-waf.pl
+++ b/tools/modsec2lua-resty-waf.pl
@@ -672,7 +672,7 @@ sub translate_options {
 			my $element = join '.', @elements;
 
 			# no $val, perhaps a delete?
-			if (!$val) {
+			if (!defined($val)) {
 				if ($var =~ m/^\!/) {
 					substr $collection, 0, 1, '';
 


### PR DESCRIPTION
$val could be zero and if it is this will evaluate to false.

changed to defined()