### PR TITLE
Missing "end" in example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,8 +219,8 @@ http {
         -- errs is an array-like table
         if errs then
             for i = 1, #errs do
-	        ngx.log(ngx.ERR, errs[i])
-	    end
+                ngx.log(ngx.ERR, errs[i])
+            end
         end
     }
 

--- a/README.md
+++ b/README.md
@@ -218,7 +218,9 @@ http {
 
         -- errs is an array-like table
         if errs then
-            for i = 1, #errs do ngx.log(ngx.ERR, errs[i])
+            for i = 1, #errs do
+	        ngx.log(ngx.ERR, errs[i])
+	    end
         end
     }
 


### PR DESCRIPTION
Indentation looks wrong in the diff but it's fine in the full-file view.